### PR TITLE
feat: Rank页面翻到下面时自动把彩蛋按钮替换成回到顶部

### DIFF
--- a/src/components/rank/rankRightContent.vue
+++ b/src/components/rank/rankRightContent.vue
@@ -56,7 +56,8 @@
   export default {
     name:'RankRightContent',
     props: {
-      endTime: String
+      endTime: String,
+      scrollVisible: { type: Boolean, default: false },
     },
     components: {
       Dialog,

--- a/src/globalCSS/iconfont.css
+++ b/src/globalCSS/iconfont.css
@@ -59,3 +59,6 @@
   content: "\e62c";
 }
 
+.icon-scroll_top:before {
+  content: "\25B2";
+}


### PR DESCRIPTION
@ch3cknull 

有个回到顶部的按钮还是很方便的捏，毕竟小作文还挺长的，一般位置都在彩蛋按钮那里，所以我直接替换掉了（回到顶部后又会出现）